### PR TITLE
Fix: Persist Laser Drill After Fill

### DIFF
--- a/Source/ED-LaserDrill/Comps/Comp_LaserDrill.cs
+++ b/Source/ED-LaserDrill/Comps/Comp_LaserDrill.cs
@@ -233,7 +233,14 @@ internal class Comp_LaserDrill : ThingComp
                 thing.DeSpawn();
                 m_RequiresShipResourcesComp.UseResources();
                 Messages.Message("EDL.steamgeyserremoved".Translate(), MessageTypeDefOf.TaskCompletion);
-                parent.Destroy();
+                if (Mod_Laser_Drill.Settings.RemoveAfterOneUse)
+                {
+                    parent.Destroy();
+                }
+                else
+                {
+                    SetRequiredDrillScanningToDefault();
+                }
                 return;
             }
 


### PR DESCRIPTION
Adds a check on filling a geyser to keep the laser drill based on the chosen mod setting.